### PR TITLE
updated config to follow established pattern

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,12 +50,12 @@ func main() {
 		userRepo,
 	)
 
-	authService := service.NewAuthService(&envConfig, userRepo)
+	authService := service.NewAuthService(&envConfig.Security.Authentication, userRepo)
 
 	routes.NewAuthRoutes(
 		router,
 		authService,
-		&envConfig,
+		&envConfig.Security.Authentication,
 	)
 
 	// http server configured with some defaults

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,14 +6,19 @@ import (
 	"strconv"
 
 	"github.com/BEOpenSourceCollabs/EventManagementCore/pkg/persist"
+	"github.com/BEOpenSourceCollabs/EventManagementCore/pkg/service"
 )
 
 // Configuration .
 type Configuration struct {
-	Secret   string
 	Env      GoEnv
 	Port     int
+	Security SecurityConfiguration
 	Database persist.DatabaseConfiguration
+}
+
+type SecurityConfiguration struct {
+	Authentication service.AuthServiceConfiguration
 }
 
 // NewEnvironmentConfiguration creates a configuration populated from os environment variables.
@@ -34,9 +39,13 @@ func NewEnvironmentConfiguration() Configuration {
 	}
 
 	return Configuration{
-		Port:   port,
-		Env:    ValidateEnv(GoEnv(env)),
-		Secret: secret,
+		Port: port,
+		Env:  ValidateEnv(GoEnv(env)),
+		Security: SecurityConfiguration{
+			Authentication: service.AuthServiceConfiguration{
+				Secret: secret,
+			},
+		},
 		Database: persist.DatabaseConfiguration{
 			Host:     os.Getenv("DATABASE_HOST"),
 			Port:     os.Getenv("DATABASE_PORT"),

--- a/pkg/net/routes/auth.go
+++ b/pkg/net/routes/auth.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/BEOpenSourceCollabs/EventManagementCore/pkg/config"
 	"github.com/BEOpenSourceCollabs/EventManagementCore/pkg/net"
 	"github.com/BEOpenSourceCollabs/EventManagementCore/pkg/net/constants"
 	"github.com/BEOpenSourceCollabs/EventManagementCore/pkg/net/dtos"
@@ -16,11 +15,11 @@ import (
 )
 
 type authRoutes struct {
-	config      *config.Configuration
+	config      *service.AuthServiceConfiguration
 	authService service.IAuthService
 }
 
-func NewAuthRoutes(router net.AppRouter, authService service.IAuthService, config *config.Configuration) *authRoutes {
+func NewAuthRoutes(router net.AppRouter, authService service.IAuthService, config *service.AuthServiceConfiguration) *authRoutes {
 
 	routes := &authRoutes{
 		authService: authService,

--- a/pkg/service/auth.service.go
+++ b/pkg/service/auth.service.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 
-	"github.com/BEOpenSourceCollabs/EventManagementCore/pkg/config"
 	"github.com/BEOpenSourceCollabs/EventManagementCore/pkg/logger"
 	"github.com/BEOpenSourceCollabs/EventManagementCore/pkg/models"
 	"github.com/BEOpenSourceCollabs/EventManagementCore/pkg/net/dtos"
@@ -24,12 +23,16 @@ type IAuthService interface {
 	CheckUser(id string) (*dtos.LoginUser, error)
 }
 
+type AuthServiceConfiguration struct {
+	Secret string
+}
+
 type AuthService struct {
-	config   *config.Configuration
+	config   *AuthServiceConfiguration
 	userRepo repository.UserRepository
 }
 
-func NewAuthService(config *config.Configuration, userRepo repository.UserRepository) IAuthService {
+func NewAuthService(config *AuthServiceConfiguration, userRepo repository.UserRepository) IAuthService {
 	return &AuthService{
 		config:   config,
 		userRepo: userRepo,


### PR DESCRIPTION
I think this pattern for the config is good and has some advantages. So I've updated the authentication service as follows:

- The service package defines the authentication service configuration
- The environment config loader initializes a instance of the configuration based of the environment variables provided at runtime.
- The main initializes the environment config and injects the config where needed. 

Can we maintain this pattern for now? We can discuss alternatives in chat if you'd prefer. 